### PR TITLE
Added check to see if passed parameters are empty.

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -230,7 +230,7 @@ class webservice_restful_server extends webservice_base_server {
      * This method parses the request sent to Moodle
      * and extracts and validates the supplied data.
      *
-     * @return void
+     * @return bool
      */
     protected function parse_request() {
 
@@ -261,8 +261,12 @@ class webservice_restful_server extends webservice_base_server {
         }
 
         // Get the webservice function parameters or return false.
-        if (!($this->parameters = $this->get_parameters())) {
-            return false;
+        if(empty($this->get_parameters())) {
+            $this->parameters = array();
+        } else {
+            if (!($this->parameters = $this->get_parameters())) {
+                return false;
+            }
         }
 
         return true;


### PR DESCRIPTION
I found that if no data is passed to the restful service that nothing is returned.

for the function, `core_webservice_get_site_info` nothing is required to be passed which was  causing the API to fail at the following block of code since an empty array is considered false in PHP

```
if (!($this->parameters = $this->get_parameters())) {
    return false;
}
```

By adding a check to see if the parameters are empty, it will allow the call to proceed.