### PR TITLE
Add overriding token for selected external functions feature

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -38,14 +38,12 @@ jobs:
       fail-fast: false
       matrix:
         database: ['pgsql']
-        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'master']
+        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'master']
         php: ['7.2', '7.4']
         exclude:
           - moodle-branch: master
             php: 7.2
           - moodle-branch: MOODLE_311_STABLE
-            php: 7.2
-          - moodle-branch: MOODLE_400_STABLE
             php: 7.2
         include:
           - moodle-branch: master

--- a/lang/en/webservice_restful.php
+++ b/lang/en/webservice_restful.php
@@ -32,3 +32,11 @@ $string['nowsfunction'] = 'No webservice function found in URL sent to Moodle';
 $string['noacceptheader'] = 'No Accept header found in request sent to Moodle';
 $string['notypeheader'] = 'No Content Type header found in request sent to Moodle';
 $string['privacy:metadata'] = 'The RESTful protocol plugin does not store any personal data.';
+
+
+$string['header'] = 'Public external api settings';
+$string['token'] = 'Token';
+$string['tokendescription'] = 'The token used to override the authentication for public external api calls';
+$string['apis'] = 'Token';
+$string['apisdescription'] = 'The token used to override the authentication for public external api calls';
+

--- a/locallib.php
+++ b/locallib.php
@@ -42,6 +42,8 @@ class webservice_restful_server extends webservice_base_server {
     /** @var string request method ('xml', 'json', or 'urlencode') */
     protected $requestformat;
 
+
+
     /**
      * Contructor
      *
@@ -52,8 +54,38 @@ class webservice_restful_server extends webservice_base_server {
         $this->wsname = 'restful';
         $this->responseformat = 'json'; // Default to json.
         $this->requestformat = 'json'; // Default to json.
+        $this->public = false;
+        $this->public_apis = $this->get_public_apis();
+        $this->public_token= $this->get_public_token();
     }
-
+    /**
+     * Get public functions names.
+     *
+     * @return array $publicapis The public apis from settings.
+     */
+    private function get_public_apis(){
+        global $CFG;
+        $config = $CFG->restful_publicapis;
+        if ($config) {
+            return explode(',', $config->value);
+        } else {
+            return array();
+        }
+    }
+    /**
+     * Get public token to be used to override public apis.
+     *
+     * @return array $token The public token from settings.
+     */
+    private function get_public_token(){
+        global $CFG;
+        $config = $CFG->restful_token;
+        if ($config) {
+            return $config;
+        } else {
+            return null;
+        } 
+    }
     /**
      * Get headers from Apache websever.
      *
@@ -118,6 +150,15 @@ class webservice_restful_server extends webservice_base_server {
     private function get_wstoken($headers) {
         $wstoken = '';
 
+        if ($this->public){
+            if ($this->public_token){
+                return $this->public_token;
+            }
+            else{
+                $ex = new \moodle_exception('notoken', 'webservice_restful', '');
+                $this->send_error($ex, 401);
+            }
+        }
         if (isset($headers['HTTP_AUTHORIZATION'])) {
             $wstoken = $headers['HTTP_AUTHORIZATION'];
         } else {
@@ -157,7 +198,10 @@ class webservice_restful_server extends webservice_base_server {
             $ex = new \moodle_exception('nowsfunction', 'webservice_restful', '');
             $this->send_error($ex, 400);
         }
-
+ 
+        if (in_array($wsfunction, $this->public_apis)) {
+            $this->public = true;
+        }
         return $wsfunction;
     }
 
@@ -237,6 +281,11 @@ class webservice_restful_server extends webservice_base_server {
         // Retrieve and clean the POST/GET parameters from the parameters specific to the server.
         parent::set_web_service_call_settings();
 
+        // Get the webservice function or return false.
+        if (!($this->functionname = $this->get_wsfunction())) {
+            return false;
+        }
+
         // Get the HTTP Headers.
         $headers = $this->get_headers();
 
@@ -255,10 +304,7 @@ class webservice_restful_server extends webservice_base_server {
             return false;
         }
 
-        // Get the webservice function or return false.
-        if (!($this->functionname = $this->get_wsfunction())) {
-            return false;
-        }
+        
 
         // Get the webservice function parameters or return false.
         if (empty($this->get_parameters())) {

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,29 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG, $PAGE, $DB;
+
+
+if ($ADMIN->fulltree) {
+
+
+        $name = 'restful_token';
+        $title = get_string('token', 'webservice_restful');
+        $description = get_string('tokendescription', 'webservice_restful');
+        $setting = new admin_setting_configtext($name, $title, $description, null);
+        $settings->add($setting);  
+        $services = $DB->get_records('external_services_functions');
+        $options = array('none'=>'none');
+        foreach ($services as $service) {
+            $options[$service->functionname] = $service->functionname;
+        }
+        $options=array_unique($options);      
+        $name = 'restful_publicapis';
+        $title = get_string('apis', 'webservice_restful');
+        $description = get_string('apisdescription', 'webservice_restful');
+        $setting = new admin_setting_configmultiselect($name, $title, $description, null, $options);
+        $settings->add($setting);
+    }
+
+


### PR DESCRIPTION
This pull request adds the functionality of overriding token by a specified token in the settings of the plugin. The main use case for this feature is dealing with automated callbacks ( i.e payment callbacks), as you don't have the ability to modify callback requests to add authentication token.