### PR TITLE
[#22] Improve 4.x support

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -23,6 +23,9 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use core_external\external_api;
+use core_external\external_settings;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once("$CFG->dirroot/webservice/lib.php");
@@ -310,7 +313,6 @@ class webservice_restful_server extends webservice_base_server {
             )
         );
         $event = \core\event\webservice_function_called::create($params);
-        $event->set_legacy_logdata(array(SITEID, 'webservice', $this->functionname, '' , getremoteaddr() , 0, $this->userid));
         $event->trigger();
 
         // Do additional setup stuff.
@@ -409,7 +411,9 @@ class webservice_restful_server extends webservice_base_server {
         if ($this->responseformat != 'xml') {
             $errorobject = new stdClass;
             $errorobject->exception = get_class($ex);
-            $errorobject->errorcode = $ex->errorcode;
+            if (isset($ex->errorcode)) {
+                $errorobject->errorcode = $ex->errorcode;
+            }
             $errorobject->message = $ex->getMessage();
             if (debugging() and isset($ex->debuginfo)) {
                 $errorobject->debuginfo = $ex->debuginfo;


### PR DESCRIPTION
Related to #22 

Note in 4.4+ Whoops will capture exceptions when using this plugin - its been logged here https://tracker.moodle.org/browse/MDL-80759 

To do:
- [ ] Check compatibility with older versions - does this need a stable branch fork
- [ ] Update README
- [ ] Switch CI to reusable workflows so 4.0+ is tested https://github.com/catalyst/catalyst-moodle-workflows