### PR TITLE
Fix issues related to Moodle coding standards

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -24,8 +24,6 @@
 
 namespace webservice_restful\privacy;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Privacy provider implementation for webservice_restful.
  *
@@ -43,7 +41,7 @@ class provider implements \core_privacy\local\metadata\null_provider {
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason(): string {
         return 'privacy:metadata';
     }
 }

--- a/db/access.php
+++ b/db/access.php
@@ -26,13 +26,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$capabilities = array(
-
-    'webservice/restful:use' => array(
+$capabilities = [
+    'webservice/restful:use' => [
         'captype' => 'read', // In fact this may be considered read and write at the same time.
         'contextlevel' => CONTEXT_COURSE, // The context level should be probably CONTEXT_MODULE.
-        'archetypes' => array(
-        ),
-    ),
-
-);
+        'archetypes' => [],
+    ],
+];

--- a/lang/en/webservice_restful.php
+++ b/lang/en/webservice_restful.php
@@ -24,11 +24,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$string['pluginname'] = 'RESTful protocol';
-$string['restful:use'] = 'Use RESTful protocol';
-
-$string['noauthheader'] = 'No Authorization header found in request sent to Moodle';
-$string['nowsfunction'] = 'No webservice function found in URL sent to Moodle';
 $string['noacceptheader'] = 'No Accept header found in request sent to Moodle';
+$string['noauthheader'] = 'No Authorization header found in request sent to Moodle';
 $string['notypeheader'] = 'No Content Type header found in request sent to Moodle';
+$string['nowsfunction'] = 'No webservice function found in URL sent to Moodle';
+$string['pluginname'] = 'RESTful protocol';
 $string['privacy:metadata'] = 'The RESTful protocol plugin does not store any personal data.';
+$string['restful:use'] = 'Use RESTful protocol';

--- a/locallib.php
+++ b/locallib.php
@@ -63,16 +63,16 @@ class webservice_restful_server extends webservice_base_server {
      * @return array $returnheaders The headers from Apache.
      */
     private function get_apache_headers() {
-        $capitalizearray = array(
+        $capitalizearray = [
             'Content-Type',
             'Accept',
             'Authorization',
             'Content-Length',
             'User-Agent',
-            'Host'
-        );
+            'Host',
+        ];
         $headers = apache_request_headers();
-        $returnheaders = array();
+        $returnheaders = [];
 
         foreach ($headers as $key => $value) {
             if (in_array($key, $capitalizearray)) {
@@ -92,7 +92,7 @@ class webservice_restful_server extends webservice_base_server {
      * @return array $headers HTTP headers.
      */
     private function get_headers($headers=null) {
-        $returnheaders = array();
+        $returnheaders = [];
 
         if (!$headers) {
             if (function_exists('apache_request_headers')) {  // Apache websever.
@@ -265,7 +265,7 @@ class webservice_restful_server extends webservice_base_server {
 
         // Get the webservice function parameters or return false.
         if (empty($this->get_parameters())) {
-            $this->parameters = array();
+            $this->parameters = [];
         } else if (!($this->parameters = $this->get_parameters())) {
             return false;
         }
@@ -292,7 +292,7 @@ class webservice_restful_server extends webservice_base_server {
         // Set up exception handler first, we want to sent them back in correct format that
         // the other system understands.
         // We do not need to call the original default handler because this ws handler does everything.
-        set_exception_handler(array($this, 'exception_handler'));
+        set_exception_handler([$this, 'exception_handler']);
 
         // Init all properties from the request data.
         if (!$this->parse_request()) {
@@ -307,11 +307,11 @@ class webservice_restful_server extends webservice_base_server {
         $this->load_function_info();
 
         // Log the web service request.
-        $params = array(
-            'other' => array(
-                'function' => $this->functionname
-            )
-        );
+        $params = [
+            'other' => [
+                'function' => $this->functionname,
+            ],
+        ];
         $event = \core\event\webservice_function_called::create($params);
         $event->trigger();
 
@@ -415,7 +415,7 @@ class webservice_restful_server extends webservice_base_server {
                 $errorobject->errorcode = $ex->errorcode;
             }
             $errorobject->message = $ex->getMessage();
-            if (debugging() and isset($ex->debuginfo)) {
+            if (debugging() && isset($ex->debuginfo)) {
                 $errorobject->debuginfo = $ex->debuginfo;
             }
             $error = json_encode($errorobject);
@@ -425,7 +425,7 @@ class webservice_restful_server extends webservice_base_server {
             $error .= '<ERRORCODE>' . htmlspecialchars($ex->errorcode, ENT_COMPAT, 'UTF-8')
                     . '</ERRORCODE>' . "\n";
             $error .= '<MESSAGE>'.htmlspecialchars($ex->getMessage(), ENT_COMPAT, 'UTF-8').'</MESSAGE>'."\n";
-            if (debugging() and isset($ex->debuginfo)) {
+            if (debugging() && isset($ex->debuginfo)) {
                 $error .= '<DEBUGINFO>'.htmlspecialchars($ex->debuginfo, ENT_COMPAT, 'UTF-8').'</DEBUGINFO>'."\n";
             }
             $error .= '</EXCEPTION>'."\n";

--- a/tests/server_test.php
+++ b/tests/server_test.php
@@ -14,13 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Restful server tests.
- *
- * @package    webservice_restful
- * @copyright  Matt Porritt <mattp@catalyst-au.net>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace webservice_restful;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -34,13 +28,15 @@ require_once($CFG->dirroot . '/webservice/restful/locallib.php');
  * @copyright  Matt Porritt <mattp@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class webservice_restful_server_testcase extends advanced_testcase {
+class server_test extends \advanced_testcase {
 
     /**
      * Test get header method extracts HTTP headers.
+     *
+     * @covers ::get_headers()
      */
-    public function test_get_headers() {
-        $headers = array(
+    public function test_get_headers(): void {
+        $headers = [
             'USER' => 'www-data',
             'HOME' => '/var/www',
             'HTTP_CONTENT_LENGTH' => '17',
@@ -54,23 +50,23 @@ class webservice_restful_server_testcase extends advanced_testcase {
             'SERVER_PORT' => '80',
             'SERVER_ADDR' => '192.168.56.103',
             'REMOTE_PORT' => '39402',
-            'REMOTE_ADDR' => '192.168.56.1'
-        );
-        $expected = array(
+            'REMOTE_ADDR' => '192.168.56.1',
+        ];
+        $expected = [
             'HTTP_CONTENT_LENGTH' => '17',
             'HTTP_AUTHORIZATION' => 'e71561c88ca7f0f0c94fee66ca07247b',
             'HTTP_ACCEPT' => 'application/json',
             'HTTP_CONTENT_TYPE' => 'application/x-www-form-urlencoded',
             'HTTP_USER_AGENT' => 'curl/7.47.0',
             'HTTP_HOST' => 'moodle.local',
-        );
+        ];
 
         $builder = $this->getMockBuilder('webservice_restful_server');
         $builder->disableOriginalConstructor();
         $stub = $builder->getMock();
 
         // We're testing a private method, so we need to setup reflector magic.
-        $method = new ReflectionMethod('webservice_restful_server', 'get_headers');
+        $method = new \ReflectionMethod('webservice_restful_server', 'get_headers');
         $method->setAccessible(true); // Allow accessing of private method.
         $proxy = $method->invoke($stub, $headers); // Get result of invoked method.
 
@@ -79,14 +75,15 @@ class webservice_restful_server_testcase extends advanced_testcase {
 
     /**
      * Test get wstoken method extracts token.
+     *
+     * @covers ::get_wstoken()
      */
-    public function test_get_wstoken() {
-        $headers = array(
+    public function test_get_wstoken(): void {
+        $headers = [
             'HTTP_AUTHORIZATION' => 'e71561c88ca7f0f0c94fee66ca07247b',
             'HTTP_ACCEPT' => 'application/json',
             'HTTP_CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-
-        );
+        ];
         $expected = 'e71561c88ca7f0f0c94fee66ca07247b';
 
         $builder = $this->getMockBuilder('webservice_restful_server');
@@ -94,7 +91,7 @@ class webservice_restful_server_testcase extends advanced_testcase {
         $stub = $builder->getMock();
 
         // We're testing a private method, so we need to setup reflector magic.
-        $method = new ReflectionMethod('webservice_restful_server', 'get_wstoken');
+        $method = new \ReflectionMethod('webservice_restful_server', 'get_wstoken');
         $method->setAccessible(true); // Allow accessing of private method.
         $proxy = $method->invoke($stub, $headers); // Get result of invoked method.
 
@@ -104,24 +101,27 @@ class webservice_restful_server_testcase extends advanced_testcase {
     /**
      * Test get wstoken method correctly errors.
      *
+     * @covers ::get_wstoken()
      */
-    public function test_get_wstoken_error() {
-        $headers = array();
+    public function test_get_wstoken_error(): void {
+        $headers = [];
         $this->expectOutputString('{"exception":"moodle_exception",'
                                 .'"errorcode":"noauthheader",'
                                 .'"message":"No Authorization header found in request sent to Moodle"}');
 
         // We're testing a private method, so we need to setup reflector magic.
-        $method = new ReflectionMethod('webservice_restful_server', 'get_wstoken');
+        $method = new \ReflectionMethod('webservice_restful_server', 'get_wstoken');
         $method->setAccessible(true); // Allow accessing of private method.
-        $proxy = $method->invoke(new webservice_restful_server(WEBSERVICE_AUTHMETHOD_PERMANENT_TOKEN), $headers);
+        $proxy = $method->invoke(new \webservice_restful_server(WEBSERVICE_AUTHMETHOD_PERMANENT_TOKEN), $headers);
     }
 
     /**
      * Test get wsfunction method extracts function.
+     *
+     * @covers ::get_wsfunction()
      */
-    public function test_get_wsfunction() {
-        $getvars = array('file' => '/core_course_get_courses');
+    public function test_get_wsfunction(): void {
+        $getvars = ['file' => '/core_course_get_courses'];
         $expected = 'core_course_get_courses';
 
         $builder = $this->getMockBuilder('webservice_restful_server');
@@ -129,7 +129,7 @@ class webservice_restful_server_testcase extends advanced_testcase {
         $stub = $builder->getMock();
 
         // We're testing a private method, so we need to setup reflector magic.
-        $method = new ReflectionMethod('webservice_restful_server', 'get_wsfunction');
+        $method = new \ReflectionMethod('webservice_restful_server', 'get_wsfunction');
         $method->setAccessible(true); // Allow accessing of private method.
         $proxy = $method->invoke($stub, $getvars); // Get result of invoked method.
 
@@ -138,29 +138,32 @@ class webservice_restful_server_testcase extends advanced_testcase {
 
     /**
      * Test get wsfunction method correctly errors.
+     *
+     * @covers ::get_wsfunction()
      */
-    public function test_get_wsfunction_error() {
-        $getvars = array();
+    public function test_get_wsfunction_error(): void {
+        $getvars = [];
         $this->expectOutputString('{"exception":"moodle_exception",'
                                 .'"errorcode":"nowsfunction",'
                                 .'"message":"No webservice function found in URL sent to Moodle"}');
 
         // We're testing a private method, so we need to setup reflector magic.
-        $method = new ReflectionMethod('webservice_restful_server', 'get_wsfunction');
+        $method = new \ReflectionMethod('webservice_restful_server', 'get_wsfunction');
         $method->setAccessible(true); // Allow accessing of private method.
-        $proxy = $method->invoke(new webservice_restful_server(WEBSERVICE_AUTHMETHOD_PERMANENT_TOKEN), $getvars);
+        $proxy = $method->invoke(new \webservice_restful_server(WEBSERVICE_AUTHMETHOD_PERMANENT_TOKEN), $getvars);
     }
 
     /**
      * Test get response format method extracts response format.
+     *
+     * @covers ::get_responseformat()
      */
-    public function test_get_responseformat() {
-        $headers = array(
+    public function test_get_responseformat(): void {
+        $headers = [
             'HTTP_AUTHORIZATION' => 'e71561c88ca7f0f0c94fee66ca07247b',
             'HTTP_ACCEPT' => 'application/json',
             'HTTP_CONTENT_TYPE' => 'application/xml',
-
-        );
+        ];
         $expected = 'json';
 
         $builder = $this->getMockBuilder('webservice_restful_server');
@@ -168,7 +171,7 @@ class webservice_restful_server_testcase extends advanced_testcase {
         $stub = $builder->getMock();
 
         // We're testing a private method, so we need to setup reflector magic.
-        $method = new ReflectionMethod('webservice_restful_server', 'get_responseformat');
+        $method = new \ReflectionMethod('webservice_restful_server', 'get_responseformat');
         $method->setAccessible(true); // Allow accessing of private method.
         $proxy = $method->invoke($stub, $headers); // Get result of invoked method.
 
@@ -177,29 +180,32 @@ class webservice_restful_server_testcase extends advanced_testcase {
 
     /**
      * Test get response format method correctly errors.
+     *
+     * @covers ::get_responseformat()
      */
-    public function test_get_responseformat_error() {
-        $headers = array();
+    public function test_get_responseformat_error(): void {
+        $headers = [];
         $this->expectOutputString('{"exception":"moodle_exception",'
                                 .'"errorcode":"noacceptheader",'
                                 .'"message":"No Accept header found in request sent to Moodle"}');
 
         // We're testing a private method, so we need to setup reflector magic.
-        $method = new ReflectionMethod('webservice_restful_server', 'get_responseformat');
+        $method = new \ReflectionMethod('webservice_restful_server', 'get_responseformat');
         $method->setAccessible(true); // Allow accessing of private method.
-        $proxy = $method->invoke(new webservice_restful_server(WEBSERVICE_AUTHMETHOD_PERMANENT_TOKEN), $headers);
+        $proxy = $method->invoke(new \webservice_restful_server(WEBSERVICE_AUTHMETHOD_PERMANENT_TOKEN), $headers);
     }
 
     /**
      * Test get request format method extracts request format.
+     *
+     * @covers ::get_requestformat()
      */
-    public function test_get_requestformat() {
-        $headers = array(
+    public function test_get_requestformat(): void {
+        $headers = [
             'HTTP_AUTHORIZATION' => 'e71561c88ca7f0f0c94fee66ca07247b',
             'HTTP_ACCEPT' => 'application/json',
             'HTTP_CONTENT_TYPE' => 'application/xml',
-
-        );
+        ];
         $expected = 'xml';
 
         $builder = $this->getMockBuilder('webservice_restful_server');
@@ -207,7 +213,7 @@ class webservice_restful_server_testcase extends advanced_testcase {
         $stub = $builder->getMock();
 
         // We're testing a private method, so we need to setup reflector magic.
-        $method = new ReflectionMethod('webservice_restful_server', 'get_requestformat');
+        $method = new \ReflectionMethod('webservice_restful_server', 'get_requestformat');
         $method->setAccessible(true); // Allow accessing of private method.
         $proxy = $method->invoke($stub, $headers); // Get result of invoked method.
 
@@ -216,16 +222,18 @@ class webservice_restful_server_testcase extends advanced_testcase {
 
     /**
      * Test get request format method correctly errors.
+     *
+     * @covers ::get_requestformat()
      */
-    public function test_get_requestformat_error() {
-        $headers = array();
+    public function test_get_requestformat_error(): void {
+        $headers = [];
         $this->expectOutputString('{"exception":"moodle_exception",'
             .'"errorcode":"notypeheader",'
             .'"message":"No Content Type header found in request sent to Moodle"}');
 
         // We're testing a private method, so we need to setup reflector magic.
-        $method = new ReflectionMethod('webservice_restful_server', 'get_requestformat');
+        $method = new \ReflectionMethod('webservice_restful_server', 'get_requestformat');
         $method->setAccessible(true); // Allow accessing of private method.
-        $proxy = $method->invoke(new webservice_restful_server(WEBSERVICE_AUTHMETHOD_PERMANENT_TOKEN), $headers);
+        $proxy = $method->invoke(new \webservice_restful_server(WEBSERVICE_AUTHMETHOD_PERMANENT_TOKEN), $headers);
     }
 }

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024050600;            // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2024050600;            // Same as version.
+$plugin->version   = 2024050601;            // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2024050601;            // Same as version.
 $plugin->component = 'webservice_restful';  // Full name of the plugin (used for diagnostics).
 $plugin->requires = 2023042400;             // Requires this Moodle version.
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This is to resolve the following coding style issues:

```
webservice/restful/classes/privacy/provider.php
[(#27) Unexpected MOODLE_INTERNAL check. No side effects or multiple artifacts detected.](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/classes/privacy/provider.php#L27)
[(#46) Method name "_get_reason" should not be prefixed with an underscore to indicate visibility](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/classes/privacy/provider.php#L46)
webservice/restful/db/access.php
[(#29) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/db/access.php#L29)
[(#31) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/db/access.php#L31)
[(#34) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/db/access.php#L34)
webservice/restful/lang/en/webservice_restful.php
[(#30) The string key "noauthheader" is not in the correct order, it should be before "restful:use"](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/lang/en/webservice_restful.php#L30)
[(#32) The string key "noacceptheader" is not in the correct order, it should be before "nowsfunction"](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/lang/en/webservice_restful.php#L32)
webservice/restful/locallib.php
[(#66) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/locallib.php#L66)
[(#72) There should be a comma after the last array item in a multi-line array.](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/locallib.php#L72)
[(#75) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/locallib.php#L75)
[(#95) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/locallib.php#L95)
[(#268) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/locallib.php#L268)
[(#295) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/locallib.php#L295)
[(#310) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/locallib.php#L310)
[(#311) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/locallib.php#L311)
[(#312) There should be a comma after the last array item in a multi-line array.](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/locallib.php#L312)
[(#313) There should be a comma after the last array item in a multi-line array.](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/locallib.php#L313)
[(#418) Logical operator "and" is prohibited; use "&&" instead](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/locallib.php#L418)
[(#428) Logical operator "and" is prohibited; use "&&" instead](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/locallib.php#L428)
webservice/restful/server.php
[(#32) Expected login check (require_login, require_course_login, require_admin, admin_externalpage_setup) following config inclusion. None found.](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/server.php#L32)
webservice/restful/tests/server_test.php
[(#37) Testcase webservice_restful_server_testcase should be declared as abstract.](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L37)
[(#37) PHPUnit testcase name "webservice_restful_server_testcase" does not match file name "server_test"](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L37)
[(#37) PHPUnit class "webservice_restful_server_testcase" does not have any namespace. It is recommended to add it to the "webservice_restful" namespace, using more levels if needed, in order to match the code being tested](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L37)
[(#42) Test method test_get_headers() is missing any coverage information, own or at class level](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L42)
[(#42) Test method test_get_headers() is missing a return type](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L42)
[(#43) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L43)
[(#57) There should be a comma after the last array item in a multi-line array.](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L57)
[(#59) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L59)
[(#83) Test method test_get_wstoken() is missing any coverage information, own or at class level](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L83)
[(#83) Test method test_get_wstoken() is missing a return type](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L83)
[(#84) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L84)
[(#108) Test method test_get_wstoken_error() is missing any coverage information, own or at class level](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L108)
[(#108) Test method test_get_wstoken_error() is missing a return type](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L108)
[(#109) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L109)
[(#123) Test method test_get_wsfunction() is missing any coverage information, own or at class level](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L123)
[(#123) Test method test_get_wsfunction() is missing a return type](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L123)
[(#124) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L124)
[(#142) Test method test_get_wsfunction_error() is missing any coverage information, own or at class level](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L142)
[(#142) Test method test_get_wsfunction_error() is missing a return type](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L142)
[(#143) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L143)
[(#157) Test method test_get_responseformat() is missing any coverage information, own or at class level](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L157)
[(#157) Test method test_get_responseformat() is missing a return type](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L157)
[(#158) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L158)
[(#181) Test method test_get_responseformat_error() is missing any coverage information, own or at class level](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L181)
[(#181) Test method test_get_responseformat_error() is missing a return type](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L181)
[(#182) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L182)
[(#196) Test method test_get_requestformat() is missing any coverage information, own or at class level](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L196)
[(#196) Test method test_get_requestformat() is missing a return type](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L196)
[(#197) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L197)
[(#220) Test method test_get_requestformat_error() is missing any coverage information, own or at class level](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L220)
[(#220) Test method test_get_requestformat_error() is missing a return type](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L220)
[(#221) Short array syntax must be used to define arrays](https://git.in.moodle.com/pluginsbot/moodle-plugins-snapshots/blob/747ccf27ad8a2ed7f45f99c55b54d5886ca7a092/webservice/restful/tests/server_test.php#L221)
```