### PR TITLE
Process GET parameters if they exist

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -226,6 +226,15 @@ class webservice_restful_server extends webservice_base_server {
             $parameters = $_POST;
         }
 
+        // Process GET variables if they exist.
+        if ($_GET) {
+            foreach ($_GET as $key => $value) {
+                if (!isset($parameters[$key])) {
+                    $parameters[$key] = $value;
+                }
+            }
+        }
+
         return $parameters;
     }
 


### PR DESCRIPTION
The current implementation assumes all requests are POST requests, and would only process POST parameters. This PR checks GET parameters.