### PR TITLE
Update test cases for Moodle 4.5 upgrade

### DIFF
--- a/tests/server_test.php
+++ b/tests/server_test.php
@@ -105,14 +105,24 @@ class server_test extends \advanced_testcase {
      */
     public function test_get_wstoken_error(): void {
         $headers = [];
-        $this->expectOutputString('{"exception":"moodle_exception",'
-                                .'"errorcode":"noauthheader",'
-                                .'"message":"No Authorization header found in request sent to Moodle"}');
+
+        // Capture the output instead of expecting a specific string
+        ob_start();
 
         // We're testing a private method, so we need to setup reflector magic.
         $method = new \ReflectionMethod('webservice_restful_server', 'get_wstoken');
         $method->setAccessible(true); // Allow accessing of private method.
         $proxy = $method->invoke(new \webservice_restful_server(WEBSERVICE_AUTHMETHOD_PERMANENT_TOKEN), $headers);
+
+        $output = ob_get_clean();
+
+        // Parse JSON and verify individual components
+        $decoded = json_decode($output, true);
+
+        $this->assertIsArray($decoded, 'Output should be valid JSON');
+        $this->assertStringEndsWith('moodle_exception', $decoded['exception']);
+        $this->assertEquals('noauthheader', $decoded['errorcode']);
+        $this->assertEquals('No Authorization header found in request sent to Moodle', $decoded['message']);
     }
 
     /**
@@ -143,14 +153,24 @@ class server_test extends \advanced_testcase {
      */
     public function test_get_wsfunction_error(): void {
         $getvars = [];
-        $this->expectOutputString('{"exception":"moodle_exception",'
-                                .'"errorcode":"nowsfunction",'
-                                .'"message":"No webservice function found in URL sent to Moodle"}');
+
+        // Capture the output instead of expecting a specific string
+        ob_start();
 
         // We're testing a private method, so we need to setup reflector magic.
         $method = new \ReflectionMethod('webservice_restful_server', 'get_wsfunction');
         $method->setAccessible(true); // Allow accessing of private method.
         $proxy = $method->invoke(new \webservice_restful_server(WEBSERVICE_AUTHMETHOD_PERMANENT_TOKEN), $getvars);
+
+        $output = ob_get_clean();
+
+        // Parse JSON and verify individual components
+        $decoded = json_decode($output, true);
+
+        $this->assertIsArray($decoded, 'Output should be valid JSON');
+        $this->assertStringEndsWith('moodle_exception', $decoded['exception']);
+        $this->assertEquals('nowsfunction', $decoded['errorcode']);
+        $this->assertEquals('No webservice function found in URL sent to Moodle', $decoded['message']);
     }
 
     /**
@@ -185,14 +205,24 @@ class server_test extends \advanced_testcase {
      */
     public function test_get_responseformat_error(): void {
         $headers = [];
-        $this->expectOutputString('{"exception":"moodle_exception",'
-                                .'"errorcode":"noacceptheader",'
-                                .'"message":"No Accept header found in request sent to Moodle"}');
+
+        // Capture the output instead of expecting a specific string
+        ob_start();
 
         // We're testing a private method, so we need to setup reflector magic.
         $method = new \ReflectionMethod('webservice_restful_server', 'get_responseformat');
         $method->setAccessible(true); // Allow accessing of private method.
         $proxy = $method->invoke(new \webservice_restful_server(WEBSERVICE_AUTHMETHOD_PERMANENT_TOKEN), $headers);
+
+        $output = ob_get_clean();
+
+        // Parse JSON and verify individual components
+        $decoded = json_decode($output, true);
+
+        $this->assertIsArray($decoded, 'Output should be valid JSON');
+        $this->assertStringEndsWith('moodle_exception', $decoded['exception']);
+        $this->assertEquals('noacceptheader', $decoded['errorcode']);
+        $this->assertEquals('No Accept header found in request sent to Moodle', $decoded['message']);
     }
 
     /**
@@ -227,13 +257,23 @@ class server_test extends \advanced_testcase {
      */
     public function test_get_requestformat_error(): void {
         $headers = [];
-        $this->expectOutputString('{"exception":"moodle_exception",'
-            .'"errorcode":"notypeheader",'
-            .'"message":"No Content Type header found in request sent to Moodle"}');
+
+        // Capture the output instead of expecting a specific string
+        ob_start();
 
         // We're testing a private method, so we need to setup reflector magic.
         $method = new \ReflectionMethod('webservice_restful_server', 'get_requestformat');
         $method->setAccessible(true); // Allow accessing of private method.
         $proxy = $method->invoke(new \webservice_restful_server(WEBSERVICE_AUTHMETHOD_PERMANENT_TOKEN), $headers);
+
+        $output = ob_get_clean();
+
+        // Parse JSON and verify individual components
+        $decoded = json_decode($output, true);
+
+        $this->assertIsArray($decoded, 'Output should be valid JSON');
+        $this->assertStringEndsWith('moodle_exception', $decoded['exception']);
+        $this->assertEquals('notypeheader', $decoded['errorcode']);
+        $this->assertEquals('No Content Type header found in request sent to Moodle', $decoded['message']);
     }
 }

--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024050603;            // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2024050603;            // Same as version.
+$plugin->version   = 2024050604;            // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2024050604;            // Same as version.
 $plugin->component = 'webservice_restful';  // Full name of the plugin (used for diagnostics).
 $plugin->requires = 2023042400;             // Requires this Moodle version.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->supported = [402, 404];            // A range of branch numbers of supported moodle versions.
+$plugin->supported = [402, 405];            // A range of branch numbers of supported moodle versions.


### PR DESCRIPTION
Dear Catalyst team,

As you know, we have been testing/using the plugin in Moodle 4.5 for a while now. We aim to add official Moodle 4.5 support to the plugin in this PR.

- Functionally the plugin works well without error.
- We have verified that the plugin doesn't use any deprecated core Moodle functions.
- The only issue we found is that 4 out of 9 test cases failed because Moodle 4.5 introduced namespaced exception classes, so `moodle_exception` became `core\exception\moodle_exception`. To solve this issue, the approach we have taken is to replace the current complete output string comparison with a logic that parses the JSON output string, compares component by component, and allows namespace contents in the "exception" component comparison. This approach is not brittle to JSON formatting changes, and provides more readability and maintainability. It works in both (pre-)4.4 and 4.5 versions too.

@mark-webster-catalyst and @danmarsden, please review the PR and let me know if you have any questions.

Regards,
Lai